### PR TITLE
adding London Business School as a school domain

### DIFF
--- a/lib/domains/edu/london.txt
+++ b/lib/domains/edu/london.txt
@@ -1,0 +1,1 @@
+London Business School


### PR DESCRIPTION
london.edu was not recognized. this is to add London Business School domain to the list. Thanks!